### PR TITLE
Improve separator UI visibility and usability

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -247,11 +247,11 @@
 
 	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
-		class="hidden h-full w-1 cursor-col-resize items-center justify-center bg-gray-100 select-none hover:bg-blue-200 active:bg-blue-200 sm:flex dark:bg-gray-700 dark:hover:bg-blue-900 dark:active:bg-blue-900"
+		class="hidden h-full w-2 cursor-col-resize items-center justify-center bg-gray-100 select-none hover:bg-blue-200 active:bg-blue-200 sm:flex dark:bg-gray-700 dark:hover:bg-blue-900 dark:active:bg-blue-900"
 		style="left: calc({leftWidth}% - 4px); z-index:10;"
 		on:mousedown={startDragVertical}
 	>
-		<div class="h-12 w-[0.05rem] rounded-full bg-gray-400"></div>
+		<div class="h-12 w-0.5 rounded-full bg-gray-400"></div>
 	</div>
 
 	<div
@@ -274,11 +274,11 @@
 
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
-			class="hidden h-1 w-full cursor-row-resize items-center justify-center bg-gray-100 select-none hover:bg-blue-200 active:bg-blue-200 sm:flex dark:bg-gray-700 dark:hover:bg-blue-900 dark:active:bg-blue-900"
+			class="hidden h-2 w-full cursor-row-resize items-center justify-center bg-gray-100 select-none hover:bg-blue-200 active:bg-blue-200 sm:flex dark:bg-gray-700 dark:hover:bg-blue-900 dark:active:bg-blue-900"
 			style="top: calc({topHeight}% - 4px); z-index:10;"
 			on:mousedown={startDragHorizontal}
 		>
-			<div class="h-[0.05rem] w-12 rounded-full bg-gray-400"></div>
+			<div class="h-0.5 w-12 my-2 rounded-full bg-gray-400"></div>
 		</div>
 
 		<div class="w-full" style="height: {100 - topHeight}%">


### PR DESCRIPTION
## Summary

This PR improves the draggable separators (vertical and horizontal dividers between panes) to make them easier to select and drag.

### Changes:
- **Vertical separator**: Increased width from `w-1` (4px) to `w-2` (8px)
- **Horizontal separator**: Increased height from `h-1` (4px) to `h-2` (8px)
- **Visual indicators**: Made the indicator lines thicker and more visible (from `0.05rem` to `0.5`/2px)
- **Visual balance**: Added margin to horizontal indicator for better appearance

### Benefits:
- Much easier to grab and drag the separators
- Better user experience on smaller screens
- Improved accessibility for users with less precise input devices
- More intuitive visual feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)