### PR TITLE
Bump @huggingface/jinja to 0.5.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@codemirror/state": "^6.4.1",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.26.3",
-        "@huggingface/jinja": "^0.5.5",
+        "@huggingface/jinja": "^0.5.9",
         "json5": "^2.2.3",
       },
       "devDependencies": {
@@ -142,7 +142,7 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.2.8", "", { "dependencies": { "@eslint/core": "^0.13.0", "levn": "^0.4.1" } }, "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA=="],
 
-    "@huggingface/jinja": ["@huggingface/jinja@0.5.5", "", {}, "sha512-xRlzazC+QZwr6z4ixEqYHo9fgwhTZ3xNSdljlKfUFGZSdlvt166DljRELFUfFytlYOYvo3vTisA/AFOuOAzFQQ=="],
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@codemirror/state": "^6.4.1",
 		"@codemirror/theme-one-dark": "^6.1.2",
 		"@codemirror/view": "^6.26.3",
-		"@huggingface/jinja": "^0.5.5",
+		"@huggingface/jinja": "^0.5.9",
 		"json5": "^2.2.3"
 	}
 }


### PR DESCRIPTION
## Summary
- Bump `@huggingface/jinja` from `^0.5.5` to `^0.5.9` (latest)

## Test plan
- [ ] `bun install` succeeds
- [ ] `bun run dev` — playground renders and templates evaluate as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)